### PR TITLE
Improve commenting logic to not produce repetitive comments

### DIFF
--- a/client/mock/client.go
+++ b/client/mock/client.go
@@ -12,7 +12,7 @@ package mock_client
 import (
 	reflect "reflect"
 
-	go_gitlab "github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,21 +40,21 @@ func (m *MockGitlabClient) EXPECT() *MockGitlabClientMockRecorder {
 }
 
 // Comment mocks base method.
-func (m *MockGitlabClient) Comment(mr *go_gitlab.MergeRequest, comment string) error {
+func (m *MockGitlabClient) Comment(mr *gitlab.MergeRequest, title, comment string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Comment", mr, comment)
+	ret := m.ctrl.Call(m, "Comment", mr, title, comment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Comment indicates an expected call of Comment.
-func (mr_2 *MockGitlabClientMockRecorder) Comment(mr, comment any) *gomock.Call {
+func (mr_2 *MockGitlabClientMockRecorder) Comment(mr, title, comment any) *gomock.Call {
 	mr_2.mock.ctrl.T.Helper()
-	return mr_2.mock.ctrl.RecordCallWithMethodType(mr_2.mock, "Comment", reflect.TypeOf((*MockGitlabClient)(nil).Comment), mr, comment)
+	return mr_2.mock.ctrl.RecordCallWithMethodType(mr_2.mock, "Comment", reflect.TypeOf((*MockGitlabClient)(nil).Comment), mr, title, comment)
 }
 
 // GetConfigFileForMR mocks base method.
-func (m *MockGitlabClient) GetConfigFileForMR(mr *go_gitlab.MergeRequest, filePath string) (*[]byte, error) {
+func (m *MockGitlabClient) GetConfigFileForMR(mr *gitlab.MergeRequest, filePath string) (*[]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfigFileForMR", mr, filePath)
 	ret0, _ := ret[0].(*[]byte)
@@ -69,10 +69,10 @@ func (mr_2 *MockGitlabClientMockRecorder) GetConfigFileForMR(mr, filePath any) *
 }
 
 // ListMrsWithLabel mocks base method.
-func (m *MockGitlabClient) ListMrsWithLabel(label string) ([]*go_gitlab.MergeRequest, error) {
+func (m *MockGitlabClient) ListMrsWithLabel(label string) ([]*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMrsWithLabel", label)
-	ret0, _ := ret[0].([]*go_gitlab.MergeRequest)
+	ret0, _ := ret[0].([]*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -84,7 +84,7 @@ func (mr *MockGitlabClientMockRecorder) ListMrsWithLabel(label any) *gomock.Call
 }
 
 // MergeMr mocks base method.
-func (m *MockGitlabClient) MergeMr(mr *go_gitlab.MergeRequest) error {
+func (m *MockGitlabClient) MergeMr(mr *gitlab.MergeRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergeMr", mr)
 	ret0, _ := ret[0].(error)
@@ -98,10 +98,10 @@ func (mr_2 *MockGitlabClientMockRecorder) MergeMr(mr any) *gomock.Call {
 }
 
 // RefreshMr mocks base method.
-func (m *MockGitlabClient) RefreshMr(mr *go_gitlab.MergeRequest) (*go_gitlab.MergeRequest, error) {
+func (m *MockGitlabClient) RefreshMr(mr *gitlab.MergeRequest) (*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshMr", mr)
-	ret0, _ := ret[0].(*go_gitlab.MergeRequest)
+	ret0, _ := ret[0].(*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -54,7 +54,7 @@ func Test_RunTask(t *testing.T) {
 		mock.EXPECT().RefreshMr(mrs[0]).Return(mrs[0], nil),
 		mock.EXPECT().MergeMr(mrs[0]).Return(nil),
 		mock.EXPECT().GetConfigFileForMR(mrs[1], ".config-file.yml").Return(inactiveMergeWindow(), nil),
-		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}})).Return(nil),
+		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}}), gomock.Any()).Return(nil),
 	)
 
 	err := subject.Run()
@@ -77,9 +77,9 @@ func Test_RunTask_TimeZoneShenanigans(t *testing.T) {
 	gomock.InOrder(
 		mock.EXPECT().ListMrsWithLabel(gomock.Any()).Return(mrs, nil),
 		mock.EXPECT().GetConfigFileForMR(mrs[0], ".config-file.yml").Return(inactiveMergeWindowWithLocation(), nil),
-		mock.EXPECT().Comment(mrs[0], gomock.Not(hasSubstr{[]string{"Failed"}})).Return(nil),
+		mock.EXPECT().Comment(mrs[0], gomock.Not(hasSubstr{[]string{"Failed"}}), gomock.Any()).Return(nil),
 		mock.EXPECT().GetConfigFileForMR(mrs[1], ".config-file.yml").Return(inactiveMergeWindowWithWeek(), nil),
-		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}})).Return(nil),
+		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}}), gomock.Any()).Return(nil),
 	)
 
 	err := subject.Run()
@@ -102,9 +102,9 @@ func Test_RunTask_WithError(t *testing.T) {
 	gomock.InOrder(
 		mock.EXPECT().ListMrsWithLabel(gomock.Any()).Return(mrs, nil),
 		mock.EXPECT().GetConfigFileForMR(mrs[0], ".config-file.yml").Return(nil, errors.New("ERROR FAIL HALP")),
-		mock.EXPECT().Comment(mrs[0], hasSubstr{[]string{"Failed"}}).Return(nil),
+		mock.EXPECT().Comment(mrs[0], hasSubstr{[]string{"Failed"}}, gomock.Any()).Return(nil),
 		mock.EXPECT().GetConfigFileForMR(mrs[1], ".config-file.yml").Return(inactiveMergeWindowWithWeek(), nil),
-		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}})).Return(errors.New("COMMENT FAILED")),
+		mock.EXPECT().Comment(mrs[1], gomock.Not(hasSubstr{[]string{"Failed"}}), gomock.Any()).Return(errors.New("COMMENT FAILED")),
 	)
 
 	err := subject.Run()


### PR DESCRIPTION
## Summary

Previously, the bot would generally make a new comment when it had something to say on a particular PR, except in the case where the new comment would be exactly the same as the previous one (in which case no comment is created).

This turns out to be not quite good enough: on a regular MR that's waiting for its window, even if the status generally remains as "merge scheduled", the precise content of the comment could change slightly (e.g. when the MR becomes briefly unmergeable because tests rerun or the branch was updated), resulting in a string of similar-looking comments.

I thus devised a better system for comments. Comments now have a "title", which is written in bold. If the bot adds a new comment and detects that there is already a previous comment with the same title, the previous comment is updated. If the title differs, a new comment is always created - this way, we don't lose the record when potential errors occur, but we also don't flood the PR with repetitions of similar status updates. The most recent comment will always have the most recent status update.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
